### PR TITLE
Fixed modid to lowercase

### DIFF
--- a/src/main/kotlin/net/shadowfacts/forgelinexample/ForgelinExample.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelinexample/ForgelinExample.kt
@@ -6,7 +6,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent
 /**
  * @author shadowfacts
  */
-@Mod(modid = "ForgelinExample", modLanguageAdapter = "net.shadowfacts.forgelin.KotlinAdapter")
+@Mod(modid = "forgelinexample", modLanguageAdapter = "net.shadowfacts.forgelin.KotlinAdapter")
 object ForgelinExample {
 
 	@Mod.EventHandler


### PR DESCRIPTION
As stated in forge documentation the `modid` property in `@mod` should be in lowercase. Current version throws an error on launch caused by the current modid.

This is what the current documentation says about the mod identifier:  
["A unique identifier for the mod. It must be lowercased, and will be truncated to 64 characters in length."](https://mcforge.readthedocs.io/en/latest/gettingstarted/structuring/#what-is-mod)
